### PR TITLE
update s3 test to handle everything from their docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.1.2]
 ### Fixed
 - S3 URL test has been updated to handle everything from the docs.
 
@@ -67,7 +69,8 @@ All notable changes to this project will be documented in this file. This change
 ### Changed
 - version bump for no apparent reason.
 
-[Unreleased]: https://github.com/Liath/aws-agent/compare/0.1.1...HEAD
+[Unreleased]: https://github.com/Liath/aws-agent/compare/0.1.2...HEAD
+[0.1.2]: https://github.com/Liath/aws-agent/commit/e47bb54d5ba1ff3d81e1e069b91e726216c65259
 [0.1.1]: https://github.com/Liath/aws-agent/commit/418ce088a06a96f16e8ea89419d0b1d3237faa48
 [0.1.0]: https://github.com/Liath/aws-agent/commit/67a89c168c8c718dfc75b71ee6a0e3021eeb825b
 [0.0.9]: https://github.com/Liath/aws-agent/commit/5d051100aa288071b5ef68a7f098d59764051831

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- S3 URL test has been updated to handle everything from the docs.
 
 ## [0.1.0]
 ### Added
@@ -58,7 +60,9 @@ All notable changes to this project will be documented in this file. This change
 ### Changed
 - version bump for no apparent reason.
 
-[Unreleased]: https://github.com/Liath/aws-agent/bulk-importer/compare/0.0.9...HEAD
+[Unreleased]: https://github.com/Liath/aws-agent/compare/0.1.1...HEAD
+[0.1.1]: https://github.com/Liath/aws-agent/commit/418ce088a06a96f16e8ea89419d0b1d3237faa48
+[0.1.0]: https://github.com/Liath/aws-agent/commit/67a89c168c8c718dfc75b71ee6a0e3021eeb825b
 [0.0.9]: https://github.com/Liath/aws-agent/commit/5d051100aa288071b5ef68a7f098d59764051831
 [0.0.8]: https://github.com/Liath/aws-agent/commit/255c3d7bb42fb3422516346f2de6a1a21f037324
 [0.0.7]: https://github.com/Liath/aws-agent/commit/4f0150e176d944765700afef9d47d8241306d853

--- a/lib/manifest.json
+++ b/lib/manifest.json
@@ -28,5 +28,5 @@
     "webRequest",
     "webRequestBlocking"
   ],
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-agent",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "JSONStream": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
-      "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
+      "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
       "dev": true,
       "requires": {
         "jsonparse": "^1.2.0",
@@ -15,9 +15,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -298,9 +298,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "bach": {
@@ -388,9 +388,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
     },
     "bl": {
@@ -536,9 +536,9 @@
       "dev": true
     },
     "browserify": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.2.2.tgz",
-      "integrity": "sha512-fMES05wq1Oukts6ksGUU2TMVHHp06LyQt0SIwbXIHm7waSrQmNBZePsU0iM/4f94zbvb/wHma+D1YrdzWYnF/A==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.2.3.tgz",
+      "integrity": "sha512-zQt/Gd1+W+IY+h/xX2NYMW4orQWhqSwyV+xsblycTtpOuB27h1fZhhNQuipJ4t79ohw4P4mMem0jp/ZkISQtjQ==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.3",
@@ -617,14 +617,23 @@
       }
     },
     "browserify-des": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
-      "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "browserify-rsa": {
@@ -662,9 +671,9 @@
       }
     },
     "buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-      "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -1109,13 +1118,12 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "object-keys": "^1.0.12"
       }
     },
     "define-property": {
@@ -1259,9 +1267,9 @@
       }
     },
     "elliptic": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -1619,12 +1627,6 @@
       "requires": {
         "for-in": "^1.0.1"
       }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -2353,14 +2355,40 @@
       }
     },
     "gulp-terser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gulp-terser/-/gulp-terser-1.0.1.tgz",
-      "integrity": "sha512-UwesC0Lma+rk17pS/rFjVWN4zan2v/vRKDnLbZMIZJqP236yVlbzAPvD1VWDi5u3pCYKbLGoI3ynlgVat+7u9A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/gulp-terser/-/gulp-terser-1.1.5.tgz",
+      "integrity": "sha512-WNk9DPCQgwnoWOs2FhkLYzE+Z32fi0tCHSLxjgQagdH7mbwM/ZqfygNEDgewRXX0jmGc/9gfyimHZLhZtbOj0g==",
       "dev": true,
       "requires": {
         "plugin-error": "^1.0.1",
-        "terser": "^3.7.5",
-        "through2": "^2.0.3"
+        "terser": "^3.8.2",
+        "through2": "^2.0.3",
+        "vinyl-sourcemaps-apply": "^0.2.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "terser": {
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-3.9.1.tgz",
+          "integrity": "sha512-ooRYGUP5p5pZvDQsPvNremx+/meS0tCLfxU5cfjVfnMnz1zBBsd2DcVhERpZIhOGZHzhL8y8lSYn+SlrEER8cQ==",
+          "dev": true,
+          "requires": {
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.6"
+          }
+        }
       }
     },
     "gulp-util": {
@@ -2866,13 +2894,13 @@
       }
     },
     "hash.js": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
-      "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "^1.0.1"
       },
       "dependencies": {
         "inherits": {
@@ -3557,9 +3585,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
       "dev": true,
       "optional": true
     },
@@ -3888,9 +3916,9 @@
       }
     },
     "pbkdf2": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
-      "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -4109,15 +4137,14 @@
       }
     },
     "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
       }
     },
     "rechoir": {
@@ -4291,12 +4318,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
     "set-value": {
@@ -4484,6 +4505,24 @@
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
         "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "source-map-url": {
@@ -5211,7 +5250,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -5252,11 +5291,23 @@
       },
       "dependencies": {
         "convert-source-map": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-          "dev": true
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+          "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
         }
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.5.1"
       }
     },
     "vm-browserify": {
@@ -5266,9 +5317,9 @@
       "dev": true
     },
     "webextension-polyfill": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.3.0.tgz",
-      "integrity": "sha512-SKwaW0Q3Ke/MZnYFw5J+zb4vNcDXFfP6TJxMIqFqEm+oMr3V+B1Hk6vq37rsJaglYIXkeDn5Y46M+x+ARbA+8g==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.3.1.tgz",
+      "integrity": "sha512-ISB42vlgMyM7xE1u6pREeCqmmXjLsYu/nqAR8Dl/gIAnylb+KpRpvKbVkUYNFePhhXn0Obkkc3jasOII9ztUtg==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-agent",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Chrome extension that enables access to AWS resources",
   "scripts": {
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "license": "MIT",
   "devDependencies": {
     "assert": "^1.4.1",
-    "aws4": "^1.7.0",
-    "browserify": "^16.2.2",
+    "aws4": "^1.8.0",
+    "browserify": "^16.2.3",
     "envify": "^4.1.0",
-    "gulp-cli": "^2.0.1",
-    "gulp-terser": "^1.0.1",
-    "gulp-util": "^3.0.8",
     "gulp": "^4.0.0",
+    "gulp-cli": "^2.0.1",
+    "gulp-terser": "^1.1.5",
+    "gulp-util": "^3.0.8",
     "json": "^9.0.6",
     "mocha": "^5.2.0",
     "normalize.css": "^8.0.0",
@@ -37,6 +37,6 @@
     "uglifyify": "^5.0.1",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
-    "webextension-polyfill": "^0.3.0"
+    "webextension-polyfill": "^0.3.1"
   }
 }

--- a/test/request-handler.js
+++ b/test/request-handler.js
@@ -10,6 +10,55 @@ const {
   URL,
 } = require('url'); // Requires node 7.10.0
 
+const s3urls = [
+  's3-website.us-east-2.amazonaws.com',
+  's3-website-us-east-1.amazonaws.com',
+  's3-website-us-west-1.amazonaws.com',
+  's3-website-us-west-2.amazonaws.com',
+  's3-website.ca-central-1.amazonaws.com',
+  's3-website.ap-south-1.amazonaws.com',
+  's3-website.ap-northeast-2.amazonaws.com',
+  's3-website.ap-northeast-3.amazonaws.com',
+  's3-website-ap-southeast-1.amazonaws.com',
+  's3-website-ap-southeast-2.amazonaws.com',
+  's3-website-ap-northeast-1.amazonaws.com',
+  's3-website.cn-northwest-1.amazonaws.com.cn',
+  's3-website.eu-central-1.amazonaws.com',
+  's3-website-eu-west-1.amazonaws.com',
+  's3-website.eu-west-2.amazonaws.com',
+  's3-website.eu-west-3.amazonaws.com',
+  's3-website-sa-east-1.amazonaws.com', 's3.us-east-2.amazonaws.com',
+  's3-us-east-2.amazonaws.com', 's3.dualstack.us-east-2.amazonaws.com',
+  's3.amazonaws.com', 's3.us-east-1.amazonaws.com',
+  's3-external-1.amazonaws.com', 's3.dualstack.us-east-1.amazonaws.com',
+  's3.us-west-1.amazonaws.com', 's3-us-west-1.amazonaws.com',
+  's3.dualstack.us-west-1.amazonaws.com', 's3.us-west-2.amazonaws.com',
+  's3-us-west-2.amazonaws.com', 's3.dualstack.us-west-2.amazonaws.com',
+  's3.ca-central-1.amazonaws.com', 's3-ca-central-1.amazonaws.com',
+  's3.dualstack.ca-central-1.amazonaws.com',
+  's3.ap-south-1.amazonaws.com', 's3-ap-south-1.amazonaws.com',
+  's3.dualstack.ap-south-1.amazonaws.com',
+  's3.ap-northeast-2.amazonaws.com', 's3-ap-northeast-2.amazonaws.com',
+  's3.dualstack.ap-northeast-2.amazonaws.com',
+  's3.ap-northeast-3.amazonaws.com', 's3-ap-northeast-3.amazonaws.com',
+  's3.dualstack.ap-northeast-3.amazonaws.com',
+  's3.ap-southeast-1.amazonaws.com', 's3-ap-southeast-1.amazonaws.com',
+  's3.dualstack.ap-southeast-1.amazonaws.com',
+  's3.ap-southeast-2.amazonaws.com', 's3-ap-southeast-2.amazonaws.com',
+  's3.dualstack.ap-southeast-2.amazonaws.com',
+  's3.ap-northeast-1.amazonaws.com', 's3-ap-northeast-1.amazonaws.com',
+  's3.dualstack.ap-northeast-1.amazonaws.com',
+  's3.cn-north-1.amazonaws.com.cn', 's3.cn-northwest-1.amazonaws.com.cn',
+  's3.eu-central-1.amazonaws.com', 's3-eu-central-1.amazonaws.com',
+  's3.dualstack.eu-central-1.amazonaws.com', 's3.eu-west-1.amazonaws.com',
+  's3-eu-west-1.amazonaws.com', 's3.dualstack.eu-west-1.amazonaws.com',
+  's3.eu-west-2.amazonaws.com', 's3-eu-west-2.amazonaws.com',
+  's3.dualstack.eu-west-2.amazonaws.com', 's3.eu-west-3.amazonaws.com',
+  's3-eu-west-3.amazonaws.com', 's3.dualstack.eu-west-3.amazonaws.com',
+  's3.sa-east-1.amazonaws.com', 's3-sa-east-1.amazonaws.com',
+  's3.dualstack.sa-east-1.amazonaws.com',
+];
+
 // Kind of a dirty hack
 global.TextDecoder = TextDecoder;
 global.URL = URL;
@@ -83,6 +132,18 @@ describe('Request Handler', () => {
         requestId: 'test',
       }).requestHeaders;
       assert.deepEqual(output, signedHeaders);
+    });
+  });
+  describe('- connFilter ', () => {
+    it('should skip all s3 urls', () => {
+      const fails = s3urls.filter(x => requestHandler.connFilter({
+        url: `https://${x}`,
+      }));
+
+      if (fails.length) {
+        assert.fail(`Failed S3 URL(s):
+${fails.map(x => `${x},`).join('\n')}`);
+      }
     });
   });
 });


### PR DESCRIPTION
We should now be handling everything that S3 registers, per their [docs](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).

Thank you @rapid7 for using weird S3 urls:
![this was failing](https://s3.eu-central-1.amazonaws.com/cdn.ipims-prod-0.eu-central-1.rapid7.com/ipims/b7f8b8264984f68d1281de1cdf3cae4b3cf94fb4/img/expired.svg)

